### PR TITLE
Option to not add doors not owned by Aladdin Account

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -8,8 +8,8 @@
       "name": {
         "title": "Name",
         "type": "string",
-            "default": "Garage Door",
-            "minLength": 1,
+        "default": "Garage Door",
+        "minLength": 1,
         "required": true
       },
       "username": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -8,8 +8,8 @@
       "name": {
         "title": "Name",
         "type": "string",
-        "default": "Garage Door",
-        "minLength": 1,
+            "default": "Garage Door",
+            "minLength": 1,
         "required": true
       },
       "username": {
@@ -68,6 +68,11 @@
         "title": "Log Genie API responses in debug mode",
         "type": "boolean",
         "default": false
+      },
+       "showShared": {
+        "title": "Show doors that have been shared with me",
+        "type": "boolean",  
+        "default": false
       }
     }
   },
@@ -86,7 +91,8 @@
         "doorStatusStationaryCacheTtl",
         "doorStatusTransitioningCacheTtl",
         "doorStatusPollInterval",
-        "logApiResponses"
+        "logApiResponses",
+        "showShared"
       ]
     }
   ]

--- a/src/aladdinConnect.ts
+++ b/src/aladdinConnect.ts
@@ -81,6 +81,7 @@ export interface AladdinDoor {
   serialNumber: string;
   name: string;
   hasBatteryLevel: boolean;
+  ownership: string;
 }
 
 export interface AladdinDoorStatusInfo {
@@ -125,6 +126,7 @@ export interface AladdinConnectConfig {
   doorStatusTransitioningCacheTtl?: number;
   doorStatusPollInterval?: number;
   logApiResponses?: boolean;
+  showShared?: boolean;
 }
 
 export class AladdinConnect {
@@ -262,6 +264,7 @@ export class AladdinConnect {
                     // I could not identify a better way to figure this out as I only have
                     // non-battery devices.
                     hasBatteryLevel: (door.battery_level ?? 0) > 0,
+                    ownership: device.ownership,
                   },
               ),
             );


### PR DESCRIPTION
In the Aladdin Connect app, a user can share the doors in their home with another user (separate account).  However in this Homebridge plugin, that is ignored and any doors shared with the user automatically get added to Homekit.

This pull request adds an option to ignore doors that have been shared with the user.

![2022-07-29 16_17_24-Homebridge 7A1C and 17 more pages - Personal - Microsoft​ Edge](https://user-images.githubusercontent.com/1859094/181837083-ce027e52-7a2a-4f69-8696-2bb716858cbb.png)
