### PR TITLE
Enhanced behavior in HomeKit scenes if desired TargetDoorState is already set  

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -196,9 +196,7 @@ export class GenieAladdinConnectGarageDoorAccessory {
 
   private async setTargetDoorState(value: CharacteristicValue): Promise<void> {
     const desiredStatus = this.convertTargetStateValueToDesiredStatus(value);
-    if (
-      desiredStatus === this.desiredStatus
-    ) {
+    if (desiredStatus === this.desiredStatus) {
       this.log.debug(
         '[%s] Set Characteristic TargetDoorState -> %s, already set TargetDoorState -> %s. Cancelling.',
         this.door.name,

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -196,6 +196,17 @@ export class GenieAladdinConnectGarageDoorAccessory {
 
   private async setTargetDoorState(value: CharacteristicValue): Promise<void> {
     const desiredStatus = this.convertTargetStateValueToDesiredStatus(value);
+    if (
+      desiredStatus === this.desiredStatus
+    ) {
+      this.log.debug(
+        '[%s] Set Characteristic TargetDoorState -> %s, already set TargetDoorState -> %s. Cancelling.',
+        this.door.name,
+        AladdinDesiredDoorStatus[desiredStatus],
+        AladdinDoorStatus[this.desiredStatus],
+      );
+      return;
+    }
     this.log.debug(
       '[%s] Set Characteristic TargetDoorState ->',
       this.door.name,


### PR DESCRIPTION
I ran into issues using my garage door in HomeKit scenes. Specifically, I noticed that, when the garage door is closed and the scene would call for the garage to be closed, setting the scene would fail and homebridge would log this error:

`[18/12/2022, 12:43:53] [Garage] [API] An error occurred sending command CloseDoor to door Garage; Request failed with status code 403`

It would appear that the Genie API responds with HTTP/403 when the desired state equals the current state. If API calls fail in the context of a HomeKit scene, the entire scene fails.

This PR proposes testing and logging for this condition when the characteristic is changed from HomeKit, and dropping the request. Bolting from the method early results in the scene to be successfully set.
