### PR TITLE
Typo in debug message

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -201,7 +201,7 @@ export class GenieAladdinConnectGarageDoorAccessory {
         '[%s] Set Characteristic TargetDoorState -> %s, already set TargetDoorState -> %s. Cancelling.',
         this.door.name,
         AladdinDesiredDoorStatus[desiredStatus],
-        AladdinDoorStatus[this.desiredStatus],
+        AladdinDesiredDoorStatus[this.desiredStatus],
       );
       return;
     }


### PR DESCRIPTION
My apologies for yet another PR right after the last one. The debug message was looking at the wrong `enum`.